### PR TITLE
Update tool import paths to match renamed library

### DIFF
--- a/tools/consumer/consumer.go
+++ b/tools/consumer/consumer.go
@@ -28,7 +28,7 @@ import (
   "os"
   "os/signal"
   "strconv"
-  kafka "github.com/jdamick/kafka.go"
+  kafka "github.com/jdamick/kafka"
   "syscall"
 )
 

--- a/tools/offsets/offsets.go
+++ b/tools/offsets/offsets.go
@@ -25,7 +25,7 @@ package main
 import (
   "flag"
   "fmt"
-  kafka "github.com/jdamick/kafka.go"
+  kafka "github.com/jdamick/kafka"
 )
 
 var hostname string

--- a/tools/publisher/publisher.go
+++ b/tools/publisher/publisher.go
@@ -25,7 +25,7 @@ package main
 import (
   "flag"
   "fmt"
-  kafka "github.com/jdamick/kafka.go"
+  kafka "github.com/jdamick/kafka"
   "os"
 )
 


### PR DESCRIPTION
`go get`-based installation currently fails as there's no code at the
previous path.

(Also, just in case you weren't aware, it's possible to rename a Github repository leaving a redirect in place.)
