### PR TITLE
Update Snappy import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ go:
   - tip
 
 install:
-  - go get code.google.com/p/snappy-go/snappy
+  - go get github.com/golang/snappy/snappy

--- a/payload_codec.go
+++ b/payload_codec.go
@@ -27,7 +27,7 @@ import (
 	"compress/gzip"
 	"encoding/binary"
 
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 )
 
 // compression flags


### PR DESCRIPTION
Since code.google.com is going away its location is now at http://github.com/golang/snappy