### PR TITLE
auto-resume + fixed partial message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Go language: (http://golang.org/) <br/>
 
 ## Changes
 
+### May 2015
+
+* fixed bug handling partial message at end of a fetch response when the payload is < 4 bytes
+* if the the kafka log segment being read is cleaned up, attempt resuming the consumer from the earliest available offset
+
 ### April 2015
 
 * added support for Snappy compression

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Go language: (http://golang.org/) <br/>
 * reused connection in BatchPublish(), instead of establishing a brand new connection every time.
 * applied gofmt / golint on the code (renamed Id() to ID() for compliance)
 * added comments
+* better distinction between DEBUG and ERROR logs, with info on how to get the consumer unstuck when the max fetch size is too small
 
 ### April 2013
 

--- a/consumer.go
+++ b/consumer.go
@@ -126,23 +126,6 @@ func (consumer *BrokerConsumer) ConsumeOnChannel(msgChan chan *Message, pollTime
 	return num, err
 }
 
-// reconnect from the earliest available offset after the current one becomes unavailable
-func (consumer *BrokerConsumer) reconnectFromEarliestAvailableOffset(conn *net.TCPConn) (uint64, error) {
-	_, err := conn.Write(consumer.broker.EncodeOffsetRequest(OFFSET_EARLIEST, 1))
-	if err != nil {
-		log.Println("Failed kafka offset request:", err.Error())
-		return 0, err
-	}
-
-	length, payload, err := consumer.broker.readResponse(conn)
-	log.Println("kafka offset request of", length, "bytes starting from offset", consumer.offset, payload)
-
-	if err != nil {
-		return 0, err
-	}
-	return binary.BigEndian.Uint64(payload[0:]), nil
-}
-
 // MessageHandlerFunc defines the interface for message handlers accepted by Consume()
 type MessageHandlerFunc func(msg *Message)
 

--- a/consumer.go
+++ b/consumer.go
@@ -169,6 +169,7 @@ func (consumer *BrokerConsumer) consumeWithConn(conn *net.TCPConn, handlerFunc M
 			if ErrIncompletePacket == err1 {
 				// Reached the end of the current packet and the last message is incomplete.
 				// Need a new Fetch Request from a newer offset, or a larger packet.
+				log.Println("Incomplete message at offset %d", currentOffset)
 				break
 			}
 			msgOffset := consumer.offset + currentOffset

--- a/consumer.go
+++ b/consumer.go
@@ -176,12 +176,13 @@ func (consumer *BrokerConsumer) consumeWithConn(conn *net.TCPConn, handlerFunc M
 						currentOffset)
 				} else {
 					// Partial message at end of current batch, need a new Fetch Request from a newer offset
-					log.Printf("DEBUG: Incomplete message at offset %d %d for topic '%s' (%s, partition %d)\n",
+					log.Printf("DEBUG: Incomplete message at offset %d %d for topic '%s' (%s, partition %d), fetching new batch from offset %d\n",
 						consumer.offset,
 						currentOffset,
 						consumer.broker.topic,
 						consumer.broker.hostname,
-						consumer.broker.partition)
+						consumer.broker.partition,
+						consumer.offset+currentOffset)
 				}
 				break
 			}

--- a/consumer.go
+++ b/consumer.go
@@ -174,6 +174,7 @@ func (consumer *BrokerConsumer) consumeWithConn(conn *net.TCPConn, handlerFunc M
 					log.Printf("ERROR: Incomplete message at offset %d %d, change the configuration to a larger max fetch size\n",
 						consumer.offset,
 						currentOffset)
+					log.Printf("Payload length: %d, currentOffset: %d, payload: [%x]", length, currentOffset, payload)
 				} else {
 					// Partial message at end of current batch, need a new Fetch Request from a newer offset
 					log.Printf("DEBUG: Incomplete message at offset %d %d for topic '%s' (%s, partition %d), fetching new batch from offset %d\n",

--- a/consumer.go
+++ b/consumer.go
@@ -169,7 +169,7 @@ func (consumer *BrokerConsumer) consumeWithConn(conn *net.TCPConn, handlerFunc M
 			if ErrIncompletePacket == err1 {
 				// Reached the end of the current packet and the last message is incomplete.
 				// Need a new Fetch Request from a newer offset, or a larger packet.
-				log.Println("Incomplete message at offset %d", currentOffset)
+				log.Printf("Incomplete message at offset %d %d\n", consumer.offset, currentOffset)
 				break
 			}
 			msgOffset := consumer.offset + currentOffset

--- a/consumer.go
+++ b/consumer.go
@@ -174,7 +174,6 @@ func (consumer *BrokerConsumer) consumeWithConn(conn *net.TCPConn, handlerFunc M
 					log.Printf("ERROR: Incomplete message at offset %d %d, change the configuration to a larger max fetch size\n",
 						consumer.offset,
 						currentOffset)
-					log.Printf("Payload length: %d, currentOffset: %d, payload: [%x]", length, currentOffset, payload)
 				} else {
 					// Partial message at end of current batch, need a new Fetch Request from a newer offset
 					log.Printf("DEBUG: Incomplete message at offset %d %d for topic '%s' (%s, partition %d), fetching new batch from offset %d\n",
@@ -186,6 +185,13 @@ func (consumer *BrokerConsumer) consumeWithConn(conn *net.TCPConn, handlerFunc M
 						consumer.offset+currentOffset)
 				}
 				break
+			} else if ErrMalformedPacket == err1 {
+				log.Printf("ERROR: Malformed message at offset %d %d\n",
+					consumer.offset,
+					currentOffset)
+			}
+			if err != nil {
+				log.Printf("Payload length: %d, currentOffset: %d, payload: [%x]", length, currentOffset, payload)
 			}
 			msgOffset := consumer.offset + currentOffset
 			for _, msg := range msgs {

--- a/kafka.go
+++ b/kafka.go
@@ -44,9 +44,11 @@ type Broker struct {
 }
 
 func newBroker(hostname string, topic string, partition int) *Broker {
-	return &Broker{topic: topic,
+	return &Broker{
+		topic:     topic,
 		partition: partition,
-		hostname:  hostname}
+		hostname:  hostname,
+	}
 }
 
 func (b *Broker) connect() (conn *net.TCPConn, error error) {

--- a/kafka_test.go
+++ b/kafka_test.go
@@ -230,7 +230,8 @@ func TestLongCompressedMessageRoundTripSnappy(t *testing.T) {
 }
 
 func TestMultipleCompressedMessages(t *testing.T) {
-	msgs := []*Message{NewMessage([]byte("testing")),
+	msgs := []*Message{
+		NewMessage([]byte("testing")),
 		NewMessage([]byte("multiple")),
 		NewMessage([]byte("messages")),
 	}

--- a/message.go
+++ b/message.go
@@ -132,7 +132,7 @@ func Decode(packet []byte, payloadCodecsMap map[byte]PayloadCodec) (uint32, []Me
 
 	// invalid / incomplete message
 	if nil != err || nil == message || message.totalLength < 1 {
-		log.Println(err.Error())
+		log.Println("DEBUG:", err.Error())
 		return 0, messages, err
 	}
 
@@ -150,7 +150,7 @@ func Decode(packet []byte, payloadCodecsMap map[byte]PayloadCodec) (uint32, []Me
 		start := payloadLen - messageLenLeft
 		innerMsg, err = decodeMessage(message.payload[start:], payloadCodecsMap)
 		if nil != err {
-			log.Println(err.Error())
+			log.Println("DEBUG:", err.Error())
 			if ErrIncompletePacket == err {
 				// the current top-level message is incomplete, reached end of packet
 				err = nil
@@ -171,7 +171,7 @@ func decodeMessage(packet []byte, payloadCodecsMap map[byte]PayloadCodec) (*Mess
 
 	length := binary.BigEndian.Uint32(packet[0:])
 	if length > uint32(len(packet[4:])) {
-		log.Printf("length mismatch, expected at least: %d, was: %d\n", length, len(packet[4:]))
+		log.Printf("DEBUG: length mismatch, expected at least: %d, was: %d\n", length, len(packet[4:]))
 		return nil, ErrIncompletePacket
 	}
 

--- a/payload_codec.go
+++ b/payload_codec.go
@@ -27,7 +27,7 @@ import (
 	"compress/gzip"
 	"encoding/binary"
 
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 )
 
 // compression flags

--- a/request.go
+++ b/request.go
@@ -37,6 +37,8 @@ const (
 	REQUEST_MULTIFETCH               = 2
 	REQUEST_MULTIPRODUCE             = 3
 	REQUEST_OFFSETS                  = 4
+	OFFSET_LATEST        int64       = -1
+	OFFSET_EARLIEST      int64       = -2
 )
 
 // EncodeRequestHeader marshals a request into kafka's wire format


### PR DESCRIPTION
* fixed bug handling partial message at end of a fetch response when the payload is < 4 bytes
* if the the kafka log segment being read is cleaned up, attempt resuming the consumer from the earliest available offset
* better distinction between DEBUG and ERROR logs
* updated snappy library path