### PR TITLE
Fix for Snappy library changes again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ go:
   - tip
 
 install:
-  - go get github.com/golang/snappy/snappy
+  - go get github.com/golang/snappy

--- a/payload_codec.go
+++ b/payload_codec.go
@@ -27,7 +27,7 @@ import (
 	"compress/gzip"
 	"encoding/binary"
 
-	"github.com/golang/snappy/snappy"
+	"github.com/golang/snappy"
 )
 
 // compression flags
@@ -136,11 +136,7 @@ func (codec *SnappyPayloadCodec) ID() byte {
 
 // Encode encodes the message with Snappy compression
 func (codec *SnappyPayloadCodec) Encode(data []byte) []byte {
-	encoded, err := snappy.Encode(nil, data)
-	if nil != err {
-		panic("Could not encode message: " + err.Error())
-	}
-	return encoded
+	return snappy.Encode(nil, data)
 }
 
 // Decode decodes the message with Snappy compression


### PR DESCRIPTION
Snappy keeps updating their API. https://github.com/golang/snappy