### PR TITLE
Bugs in Makefile and Consumer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ tools: force kafka
 	cd tools/publisher ; go install
 
 format:
-	gofmt -w -tabwidth=2 -tabs=false kafka
+	gofmt -w .
 
 clean:
 
 full: format clean kafka tools
 
-.PHONY: force 
+.PHONY: force

--- a/converts.go
+++ b/converts.go
@@ -23,29 +23,29 @@
 package kafka
 
 import (
-  "encoding/binary"
+	"encoding/binary"
 )
 
 func uint16bytes(value int) []byte {
-  result := make([]byte, 2)
-  binary.BigEndian.PutUint16(result, uint16(value))
-  return result
+	result := make([]byte, 2)
+	binary.BigEndian.PutUint16(result, uint16(value))
+	return result
 }
 
 func uint32bytes(value int) []byte {
-  result := make([]byte, 4)
-  binary.BigEndian.PutUint32(result, uint32(value))
-  return result
+	result := make([]byte, 4)
+	binary.BigEndian.PutUint32(result, uint32(value))
+	return result
 }
 
 func uint32toUint32bytes(value uint32) []byte {
-  result := make([]byte, 4)
-  binary.BigEndian.PutUint32(result, value)
-  return result
+	result := make([]byte, 4)
+	binary.BigEndian.PutUint32(result, value)
+	return result
 }
 
 func uint64ToUint64bytes(value uint64) []byte {
-  result := make([]byte, 8)
-  binary.BigEndian.PutUint64(result, value)
-  return result
+	result := make([]byte, 8)
+	binary.BigEndian.PutUint64(result, value)
+	return result
 }

--- a/tools/consumer/consumer.go
+++ b/tools/consumer/consumer.go
@@ -80,8 +80,8 @@ func main() {
 		}
 	}
 
+	quit := make(chan struct{})
 	if consumerForever {
-		quit := make(chan struct{})
 		go func() {
 			sigIn := make(chan os.Signal)
 			signal.Notify(sigIn)
@@ -108,7 +108,7 @@ func main() {
 			}
 		}
 	} else {
-		broker.Consume(consumerCallback)
+		broker.Consume(consumerCallback, quit)
 	}
 
 	if payloadFile != nil {


### PR DESCRIPTION
* Fixed Makefile: remove gofmt invalid flags for gofmt
* Consumer: passing "quit" empty struct to Consume function.
* Also ran gofmt, which modified whitespace in converts.go