### PR TITLE
Fix embedded frame decoding; Fix Consume() params + respect stop signal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ go:
   - tip
 
 install:
-  - go get code.google.com/p/snappy-go/snappy
+  - go get github.com/golang/snappy/snappy

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ go:
   - tip
 
 install:
-  - go get github.com/golang/snappy/snappy
+  - go get github.com/golang/snappy

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Kafka is a distributed publish-subscribe messaging system: (http://kafka.apache.
 
 Go language: (http://golang.org/) <br/>
 
+##### For Kafka 0.8.x take a look at https://github.com/Shopify/sarama
+
 ## Changes
 
 ### May 2015
@@ -79,7 +81,7 @@ The consumer should output message.
 <pre><code>
 
 broker := kafka.NewBrokerPublisher("localhost:9092", "mytesttopic", 0)
-broker.Publish(kafka.NewMessage([]byte("tesing 1 2 3")))
+broker.Publish(kafka.NewMessage([]byte("testing 1 2 3")))
 
 </code></pre>
 
@@ -89,7 +91,7 @@ broker.Publish(kafka.NewMessage([]byte("tesing 1 2 3")))
 <pre><code>
 
 broker := kafka.NewBrokerPublisher("localhost:9092", "mytesttopic", 0)
-broker.Publish(kafka.NewCompressedMessage([]byte("tesing 1 2 3")))
+broker.Publish(kafka.NewCompressedMessage([]byte("testing 1 2 3")))
 
 </code></pre>
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # kafka - Publisher & Consumer for Kafka 0.7.x in Go #
 
+[![Join the chat at https://gitter.im/jdamick/kafka](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jdamick/kafka?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 Kafka is a distributed publish-subscribe messaging system: (http://kafka.apache.org)
 
 Go language: (http://golang.org/) <br/>

--- a/payload_codec.go
+++ b/payload_codec.go
@@ -27,7 +27,7 @@ import (
 	"compress/gzip"
 	"encoding/binary"
 
-	"github.com/golang/snappy/snappy"
+	"github.com/golang/snappy"
 )
 
 // compression flags
@@ -136,11 +136,7 @@ func (codec *SnappyPayloadCodec) ID() byte {
 
 // Encode encodes the message with Snappy compression
 func (codec *SnappyPayloadCodec) Encode(data []byte) []byte {
-	encoded, err := snappy.Encode(nil, data)
-	if nil != err {
-		panic("Could not encode message: " + err.Error())
-	}
-	return encoded
+	return snappy.Encode(nil, data)
 }
 
 // Decode decodes the message with Snappy compression

--- a/publisher.go
+++ b/publisher.go
@@ -90,8 +90,7 @@ func (b *BrokerPublisher) ProduceFromChannel(msgChan chan *Message, quit chan st
 			}
 			num++
 		case <-quit:
-			break
+			return num, nil
 		}
 	}
-	return num, nil
 }

--- a/tools/consumer/consumer.go
+++ b/tools/consumer/consumer.go
@@ -108,7 +108,8 @@ func main() {
 			}
 		}
 	} else {
-		broker.Consume(consumerCallback)
+		quit := make(chan struct{})
+		broker.Consume(consumerCallback, quit)
 	}
 
 	if payloadFile != nil {


### PR DESCRIPTION
* fix edge case when reading a compressed message containing a non-compressed frame; if, during decoding, we encounter EOF at the end of the message, the entire message is discarded even if successfully decompressed/decoded. 
* fixed encoding test with correct byte sequence
* fix snappy import
* update examples to use the stop signal in the function call

This PR fixes the TravisCI build too ;-)